### PR TITLE
Fix: LogoutView should logout user on GET request

### DIFF
--- a/class_based_auth_views/views.py
+++ b/class_based_auth_views/views.py
@@ -92,6 +92,8 @@ class LogoutView(TemplateResponseMixin, View):
     def get(self, *args, **kwargs):
         if not self.request.user.is_authenticated():
             return redirect(self.get_redirect_url())
+        else:
+            auth.logout(self.request)
         context = self.get_context_data()
         return self.render_to_response(context)
 


### PR DESCRIPTION
Django built-in logout() function logs user out no matter the request method used, however LogoutView logs-user out only when POST method used.
