### PR TITLE
Add python 3 support using urllib.parse as urlparse.

### DIFF
--- a/class_based_auth_views/utils.py
+++ b/class_based_auth_views/utils.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import functools
-import urlparse
+try:
+	import urlparse
+except ImportError:
+	from urllib import parse as urlparse # python3 support
 from django.core.exceptions import SuspiciousOperation
 
 

--- a/class_based_auth_views/views.py
+++ b/class_based_auth_views/views.py
@@ -1,5 +1,8 @@
 #-*- coding: utf-8 -*-
-import urlparse
+try:
+    import urlparse
+except ImportError:
+    from urllib import parse as urlparse # python3 support
 from class_based_auth_views.utils import default_redirect
 from django.contrib import auth
 from django.contrib.auth import REDIRECT_FIELD_NAME, login


### PR DESCRIPTION
In utils.py and views.py the "import urlparse" makes incompatible with Python 3, when the module urlparse doesn't exist, instead should use urllib.parse, and if we import urllib.parse as urlparse, less change to the code.
